### PR TITLE
Remove .decode("utf-8") from outfile.write() #9

### DIFF
--- a/src/omi/cli.py
+++ b/src/omi/cli.py
@@ -37,7 +37,7 @@ def translate(f, t, o, file_path):
         s = to_dialect.compile_and_render(obj)
         if o:
             with open(o, "w") as outfile:
-                outfile.write(s.decode("utf-8"))
+                outfile.write(s)
         else:
             print(s)
 


### PR DESCRIPTION
Removes `.decode("utf-8")` and fixes the cli for me. Not sure if `.decode` is deprecated entirely in python3 or if there is a use for it that I'm not seeing. Hence the PR.