### PR TITLE
Fix get-dialect import issue

### DIFF
--- a/src/omi/dialects/__init__.py
+++ b/src/omi/dialects/__init__.py
@@ -1,2 +1,4 @@
+from omi.dialects.base.register import get_dialect
+
 import omi.dialects.oep.dialect
 import omi.dialects.rdf.dialect

--- a/src/omi/dialects/__init__.py
+++ b/src/omi/dialects/__init__.py
@@ -1,4 +1,3 @@
-from omi.dialects.base.register import get_dialect
-
 import omi.dialects.oep.dialect
 import omi.dialects.rdf.dialect
+from omi.dialects.base.register import get_dialect


### PR DESCRIPTION
Hi all,

a commit two weeks ago removed an import of get_dialect: https://github.com/OpenEnergyPlatform/omi/commit/2e3fb99bb29be615420fb13bd78c9e006eff92b4#diff-49f99fb7574a1c4dace5a6bed846ee35L3

This resulted in an error when I tried to use omi from cli:
```
cli.py", line 19, in <module>
from omi.dialects import get_dialect
ImportError: cannot import name 'get_dialect'
```
After readding the specific import line, omi works again!

@MGlauer, @Ludee or @christian-rli, please review this pull request and merge it, if your review conclusion is positive! Thx!

