### PR TITLE
Feature/add code formatting script

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,6 +14,8 @@ include CONTRIBUTING.rst
 include LICENSE
 include README.rst
 
+include *.sh
+
 include tox.ini .travis.yml appveyor.yml
 
 global-exclude *.py[cod] __pycache__ *.so *.dylib

--- a/README.rst
+++ b/README.rst
@@ -83,6 +83,14 @@ To run the all tests run::
 
     tox
 
+Code formatting. After code changes always run isort and black (in this order). You can also use following script::
+
+    bash format_code.sh
+
+    OR
+    
+    ./format_code.sh
+
 Note, to combine the coverage data from all the tox environments run:
 
 .. list-table::

--- a/format_code.sh
+++ b/format_code.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+isort -rc *.py ./src/ ./tests/
+black *.py src/ tests/

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import io
-
 import re
 from glob import glob
 from os.path import basename
@@ -21,6 +20,7 @@ def read(*names, **kwargs):
         join(dirname(__file__), *names), encoding=kwargs.get("encoding", "utf8")
     ) as fh:
         return fh.read()
+
 
 setup(
     name="omi",
@@ -72,10 +72,7 @@ setup(
         # eg: 'keyword1', 'keyword2', 'keyword3',
     ],
     python_requires=">=3.5",
-    install_requires=[
-        "click",
-        "rdfLib",
-        "python-dateutil"],
+    install_requires=["click", "rdfLib", "python-dateutil"],
     tests_require=["tox", "pytest"],
     extras_require={
         # eg:

--- a/tests/test_dialects/base/parser.py
+++ b/tests/test_dialects/base/parser.py
@@ -16,7 +16,7 @@ def assert_compileable_equal(expected, got, nulls=None, exclude=None):
     nulls = nulls or [None]
     assert isinstance(expected, (Compilable, dict)), type(expected)
     assert isinstance(got, (Compilable, dict)), (type(got), expected)
-    for key in (set(expected.__dict__.keys()).union(set(got.__dict__.keys()))):
+    for key in set(expected.__dict__.keys()).union(set(got.__dict__.keys())):
         if key not in exclude:
             l = getattr(expected, key)
             r = getattr(got, key)
@@ -26,19 +26,27 @@ def assert_compileable_equal(expected, got, nulls=None, exclude=None):
                     new_exclude = ["resource"]
                 assert_compileable_equal(l, r, nulls=nulls, exclude=new_exclude)
             elif isinstance(l, list) and isinstance(r, list):
-                assert len(l) == len(r), "Lists do not match (Expected: {}; Got: {})".format(l, r)
+                assert len(l) == len(
+                    r
+                ), "Lists do not match (Expected: {}; Got: {})".format(l, r)
                 for l0, r0 in zip(sorted(l), sorted(r)):
                     if isinstance(l0, Compilable):
                         if isinstance(l0, Field):
                             new_exclude = ["resource"]
                         else:
                             new_exclude = []
-                        assert_compileable_equal(l0, r0, nulls=nulls, exclude=new_exclude)
+                        assert_compileable_equal(
+                            l0, r0, nulls=nulls, exclude=new_exclude
+                        )
                     else:
                         assert l0 == r0, "Expected: {}; Got: {}".format(l0, r0)
             else:
                 if not (l is None and r in nulls):
-                    assert l == r, "Keys {} do not match (Expected:{}:{}; Got: {}:{})".format(key, type(l), l, type(r) ,r)
+                    assert (
+                        l == r
+                    ), "Keys {} do not match (Expected:{}:{}; Got: {}:{})".format(
+                        key, type(l), l, type(r), r
+                    )
 
 
 def parse_date(s):

--- a/tests/test_dialects/internal_structures.py
+++ b/tests/test_dialects/internal_structures.py
@@ -22,28 +22,24 @@ _target_year.resource = _target_resource
 
 
 cc010 = s.License(
-                name="Creative Commons Zero v1.0 Universal",
-                identifier="CC0-1.0",
-                path="https://creativecommons.org/publicdomain/zero/1.0/legalcode",
-                other_references=None,
-                text=None,
-            )
+    name="Creative Commons Zero v1.0 Universal",
+    identifier="CC0-1.0",
+    path="https://creativecommons.org/publicdomain/zero/1.0/legalcode",
+    other_references=None,
+    text=None,
+)
 
 odbl10 = s.License(
-                identifier="ODbL-1.0",
-                name="Open Data Commons Open Database License 1.0",
-                path="https://opendatacommons.org/licenses/odbl/1.0/",
-                other_references=None,
-                text=None,
-            )
+    identifier="ODbL-1.0",
+    name="Open Data Commons Open Database License 1.0",
+    path="https://opendatacommons.org/licenses/odbl/1.0/",
+    other_references=None,
+    text=None,
+)
 
 odbl10_13 = s.License(
-                name=None,
-                identifier="ODbL-1.0",
-                path=None,
-                other_references=None,
-                text=None,
-            )
+    name=None, identifier="ODbL-1.0", path=None, other_references=None, text=None
+)
 
 metadata_v_1_3 = s.OEPMetadata(
     name=None,
@@ -68,14 +64,14 @@ metadata_v_1_3 = s.OEPMetadata(
             description="Study financed by Organisation describes Issue. The study is authored by Jon Doe and Erika Mustermann",
             path="http://dx.doi.org/1.1/j.d.2000.01.001",
             licenses=None,
-            #source_copyright="Publisher",
+            # source_copyright="Publisher",
         ),
         s.Source(
             title="Metastudy on Issue",
             description="Study financed by State Actor evaluates Issue in regions. The study is authored by Jane Doe and Otto Normal",
             path="http://dx.doi.org/2.2/j.d.2022.02.022",
             licenses=None,
-            #source_copyright="Publisher2",
+            # source_copyright="Publisher2",
         ),
     ],
     terms_of_use=[
@@ -163,12 +159,11 @@ metadata_v_1_4 = s.OEPMetadata(
         grant_number="03ET4057",
         funding_agency=s.Agency(
             name="Bundesministerium für Wirtschaft und Energie",
-            logo="https://www.innovation-beratung-foerderung.de/INNO/Redaktion/DE/Bilder/Titelbilder/titel_foerderlogo_bmwi.jpg?__blob=poster&v=2"
+            logo="https://www.innovation-beratung-foerderung.de/INNO/Redaktion/DE/Bilder/Titelbilder/titel_foerderlogo_bmwi.jpg?__blob=poster&v=2",
         ),
         publisher=s.Agency(
             logo="https://reiner-lemoine-institut.de//wp-content/uploads/2015/09/rlilogo.png"
-        )
-
+        ),
     ),
     spatial=s.Spatial(location=None, extent="europe", resolution="100 m"),
     temporal=s.Temporal(
@@ -181,27 +176,32 @@ metadata_v_1_4 = s.OEPMetadata(
         ),
         resolution="1 h",
         ts_orientation=s.TimestampOrientation.left,
-        aggregation="sum"
+        aggregation="sum",
     ),
     sources=[
         s.Source(
             title="OpenEnergyPlatform Metadata Example",
             description="Metadata description",
             path="https://github.com/OpenEnergyPlatform",
-            licenses=[s.TermsOfUse(
-                lic=cc010,
-                instruction="You are free: To Share, To Create, To Adapt",
-                attribution="© Reiner Lemoine Institut"
-            )],
+            licenses=[
+                s.TermsOfUse(
+                    lic=cc010,
+                    instruction="You are free: To Share, To Create, To Adapt",
+                    attribution="© Reiner Lemoine Institut",
+                )
+            ],
         ),
         s.Source(
             title="OpenStreetMap",
             description="A collaborative project to create a free editable map of the world",
             path="https://www.openstreetmap.org/",
-            licenses=[s.TermsOfUse(
-                lic=odbl10,
-                instruction="You are free: To Share, To Create, To Adapt; As long as you: Attribute, Share-Alike, Keep open!",
-                attribution="© OpenStreetMap contributors")],
+            licenses=[
+                s.TermsOfUse(
+                    lic=odbl10,
+                    instruction="You are free: To Share, To Create, To Adapt; As long as you: Attribute, Share-Alike, Keep open!",
+                    attribution="© OpenStreetMap contributors",
+                )
+            ],
         ),
     ],
     terms_of_use=[

--- a/tests/test_dialects/test_oep/test_parser.py
+++ b/tests/test_dialects/test_oep/test_parser.py
@@ -23,11 +23,13 @@ def test_parser_v1_4():
     expected_result = metadata_v_1_4
     _test_generic_parsing(parser, _input_file, expected_result)
 
+
 def test_parser_v1_3_minimal():
     parser = JSONParser_1_3()
     _input_file = "tests/data/metadata_v13_minimal.json"
     expected_result = metadata_v_1_3_minimal
     _test_generic_parsing(parser, _input_file, expected_result)
+
 
 def test_parser_v1_4_minimal():
     parser = JSONParser_1_4()

--- a/tests/test_dialects/test_oep/test_translation.py
+++ b/tests/test_dialects/test_oep/test_translation.py
@@ -17,7 +17,9 @@ def test_translation_1_3_to_1_4():
         # Step 2: Translate to version 1_4
         result_json = compiler.visit(internal_metadata)
 
-        expected_json = OrderedDict(json.loads('''{
+        expected_json = OrderedDict(
+            json.loads(
+                """{
     "name": null,
     "title": null,
     "id": null,
@@ -39,6 +41,8 @@ def test_translation_1_3_to_1_4():
             "name": "CC0-1.0",
             "title": "Creative Commons Zero v1.0 Universal",
             "path": "https://creativecommons.org/publicdomain/zero/1.0/"}},
-    "_comment": null}'''))
+    "_comment": null}"""
+            )
+        )
 
         assert_equal(expected_json, result_json)

--- a/tests/test_dialects/test_rdf/test_compiler.py
+++ b/tests/test_dialects/test_rdf/test_compiler.py
@@ -5,12 +5,13 @@ from rdflib.compare import graph_diff
 from rdflib.compare import isomorphic
 from rdflib.compare import similar
 from rdflib.compare import to_isomorphic
+from rdflib.namespace import DCTERMS
 
 from omi.dialects.rdf.compiler import RDFCompiler
+from omi.dialects.rdf.namespace import OEO
 
 from ..internal_structures import metadata_v_1_4
-from omi.dialects.rdf.namespace import OEO
-from rdflib.namespace import DCTERMS
+
 
 def test_compiler_v1_4():
     compiler = RDFCompiler()


### PR DESCRIPTION
Hi @MGlauer,

please review this PR. I added a isort/black code formatting script (+ short usage description in readme) to be able to always run consistently over all relevant Python files after some code changes. I also included a commit https://github.com/OpenEnergyPlatform/omi/pull/17/commits/0199fcdfbea7c54875d363c494a2b5fff4bbee55 in which I added files which haven't yet been touched by isort and black 