### PR TITLE
Add oem validation based on jsonschema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ htmlcov
 .idea
 *.iml
 *.komodoproject
+/0_local_test
 
 # Complexity
 output/*.html
@@ -63,6 +64,7 @@ docs/_build
 .bootstrap
 .appveyor.token
 *.bak
+/1_env
 
 # Mypy Cache
 .mypy_cache/

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
         # eg: 'keyword1', 'keyword2', 'keyword3',
     ],
     python_requires=">=3.5",
-    install_requires=["click", "rdfLib", "python-dateutil", "jsonschema"],
+    install_requires=["click", "rdfLib", "python-dateutil", "jsonschema"], # TODO: add oemetadata as soon as new release on pypi (json files not inclides ATM)
     tests_require=["tox", "pytest"],
     extras_require={
         "dev": ["black", "isort", "pre-commit"]

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
         # eg: 'keyword1', 'keyword2', 'keyword3',
     ],
     python_requires=">=3.5",
-    install_requires=["click", "rdfLib", "python-dateutil"],
+    install_requires=["click", "rdfLib", "python-dateutil", "jsonschema"],
     tests_require=["tox", "pytest"],
     extras_require={
         "dev": ["black", "isort", "pre-commit"]


### PR DESCRIPTION
Implement jsonschema validation using new oemetadata test release:
- oemetadata contains json files (like schema.json) for each version. Currently this is only published on test.pypi. another way to get the schema would be to grab it directly from the oemetadata repo via http.
