### PR TITLE
oeo annotaion field names compiled to unexpected key name#64

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ current (2022-XX-XX)
 * Add conversion option to OMIs CLI application
 * Add conversion additional script that converts oemetadata from v1.4 to v1.5 without using OMI. thanks to @chrwm
 
+* Fix but with oeo related isAbout and valueReference fields (PR#65)
+
 
 0.0.7 (2022-06-02)
 ------------------

--- a/src/omi/dialects/oep/compiler.py
+++ b/src/omi/dialects/oep/compiler.py
@@ -303,8 +303,8 @@ class JSONCompilerOEM15(JSONCompiler):
             ("timeseries", temporal.timeseries_collection),
         )
 
-    def visit_is_about(self, is_about: oem_v15.IsAbout, *args, **kwargs):
-        return self._construct_dict(("name", is_about.name), ("path", is_about.path))
+    def visit_isAbout(self, isAbout: oem_v15.IsAbout, *args, **kwargs):
+        return self._construct_dict(("name", isAbout.name), ("path", isAbout.path))
 
     def visit_value_reference(
         self, value_reference: oem_v15.ValueReference, *args, **kwargs
@@ -320,7 +320,7 @@ class JSONCompilerOEM15(JSONCompiler):
             ("name", field.name),
             ("description", field.description),
             ("type", field.type),
-            ("is_about", field.is_about),
+            ("isAbout", field.isAbout),
             ("value_reference", field.value_reference),
             ("unit", field.unit),
         )

--- a/src/omi/dialects/oep/compiler.py
+++ b/src/omi/dialects/oep/compiler.py
@@ -306,13 +306,13 @@ class JSONCompilerOEM15(JSONCompiler):
     def visit_isAbout(self, isAbout: oem_v15.IsAbout, *args, **kwargs):
         return self._construct_dict(("name", isAbout.name), ("path", isAbout.path))
 
-    def visit_value_reference(
-        self, value_reference: oem_v15.ValueReference, *args, **kwargs
+    def visit_valueReference(
+        self, valueReference: oem_v15.ValueReference, *args, **kwargs
     ):
         return self._construct_dict(
-            ("value", value_reference.value),
-            ("name", value_reference.name),
-            ("path", value_reference.path),
+            ("value", valueReference.value),
+            ("name", valueReference.name),
+            ("path", valueReference.path),
         )
 
     def visit_field(self, field: oem_v15.Field, *args, **kwargs):
@@ -321,7 +321,7 @@ class JSONCompilerOEM15(JSONCompiler):
             ("description", field.description),
             ("type", field.type),
             ("isAbout", field.isAbout),
-            ("value_reference", field.value_reference),
+            ("valueReference", field.valueReference),
             ("unit", field.unit),
         )
 

--- a/src/omi/dialects/oep/parser.py
+++ b/src/omi/dialects/oep/parser.py
@@ -793,9 +793,9 @@ class JSONParser_1_5(JSONParser):
                             # filling the is about section
                             old_is_abouts = field.get("isAbout")
                             if old_is_abouts is None:
-                                is_about = None
+                                isAbout = None
                             else:
-                                is_about = [
+                                isAbout = [
                                     oem_v15.IsAbout(
                                         name=old_is_about.get("name"),
                                         path=old_is_about.get("path"),
@@ -822,7 +822,7 @@ class JSONParser_1_5(JSONParser):
                                     name=field.get("name"),
                                     description=field.get("description"),
                                     field_type=field.get("type"),
-                                    is_about=is_about,
+                                    isAbout=isAbout,
                                     value_reference=value_reference,
                                     unit=field.get("unit"),
                                 )

--- a/src/omi/dialects/oep/parser.py
+++ b/src/omi/dialects/oep/parser.py
@@ -806,9 +806,9 @@ class JSONParser_1_5(JSONParser):
                             # filling the value reference section
                             old_value_references = field.get("valueReference")
                             if old_value_references is None:
-                                value_reference = None
+                                valueReference = None
                             else:
-                                value_reference = [
+                                valueReference = [
                                     oem_v15.ValueReference(
                                         value=old_value_reference.get("value"),
                                         name=old_value_reference.get("name"),
@@ -823,7 +823,7 @@ class JSONParser_1_5(JSONParser):
                                     description=field.get("description"),
                                     field_type=field.get("type"),
                                     isAbout=isAbout,
-                                    value_reference=value_reference,
+                                    valueReference=valueReference,
                                     unit=field.get("unit"),
                                 )
                             )

--- a/src/omi/oem_structures/oem_v15.py
+++ b/src/omi/oem_structures/oem_v15.py
@@ -167,7 +167,7 @@ class Contribution(Compilable):
 
 
 class IsAbout(Compilable):
-    __compiler_name__ = "is_about"
+    __compiler_name__ = "isAbout"
 
     def __init__(self, name: str = None, path: str = None):
         self.name = name
@@ -191,7 +191,7 @@ class Field(Compilable):
         name: str = None,
         description: str = None,
         field_type: str = None,
-        is_about: Iterable[IsAbout] = None,
+        isAbout: Iterable[IsAbout] = None,
         value_reference: Iterable[ValueReference] = None,
         unit: str = None,
         resource: "Resource" = None,
@@ -199,7 +199,7 @@ class Field(Compilable):
         self.name = name
         self.description = description
         self.type = field_type
-        self.is_about = is_about
+        self.isAbout = isAbout
         self.value_reference = value_reference
         self.unit = unit
         self.resource = resource

--- a/src/omi/oem_structures/oem_v15.py
+++ b/src/omi/oem_structures/oem_v15.py
@@ -175,7 +175,7 @@ class IsAbout(Compilable):
 
 
 class ValueReference(Compilable):
-    __compiler_name__ = "value_reference"
+    __compiler_name__ = "valueReference"
 
     def __init__(self, value: str = None, name: str = None, path: str = None):
         self.value = value
@@ -192,7 +192,7 @@ class Field(Compilable):
         description: str = None,
         field_type: str = None,
         isAbout: Iterable[IsAbout] = None,
-        value_reference: Iterable[ValueReference] = None,
+        valueReference: Iterable[ValueReference] = None,
         unit: str = None,
         resource: "Resource" = None,
     ):
@@ -200,7 +200,7 @@ class Field(Compilable):
         self.description = description
         self.type = field_type
         self.isAbout = isAbout
-        self.value_reference = value_reference
+        self.valueReference = valueReference
         self.unit = unit
         self.resource = resource
 


### PR DESCRIPTION
Fix:
is_about to isAbout
value_reference to valueReferance

see oem v1.5 spec: https://github.com/OpenEnergyPlatform/oemetadata 