### PR TITLE
Make "_comment" key/field content static 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ Changelog
 current (2022-XX-XX)
 --------------------
 
+* Fix bug that is raised if the input oemetadata does not contain the key _comment (PR#74) 
+
 0.0.8 (2022-10-20)
 --------------------
 

--- a/src/omi/dialects/oep/compiler.py
+++ b/src/omi/dialects/oep/compiler.py
@@ -368,14 +368,14 @@ class JSONCompilerOEM15(JSONCompiler):
                     path="https://creativecommons.org/publicdomain/zero/1.0/",
                 ),
             ),
-            _comment=self._construct_dict( 
-                metadata=metadata.comment.metadata_info,
-                dates=metadata.comment.dates,
-                units=metadata.comment.units,
-                languages=metadata.comment.languages,
-                licenses=metadata.comment.licenses,
-                review=metadata.comment.review,
-                null=metadata.comment.null,
-                todo=metadata.comment.todo,
+            _comment=self._construct_dict(
+                metadata="Metadata documentation and explanation (https://github.com/OpenEnergyPlatform/oemetadata)",
+                dates="Dates and time must follow the ISO8601 including time zone (YYYY-MM-DD or YYYY-MM-DDThh:mm:ss±hh)",
+                units="Use a space between numbers and units (100 m)",
+                languages="Languages must follow the IETF (BCP47) format (en-GB, en-US, de-DE)",
+                licenses="License name must follow the SPDX License List (https://spdx.org/licenses/)",
+                review="Following the OEP Data Review (https://github.com/OpenEnergyPlatform/data-preprocessing/blob/master/data-review/manual/review_manual.md)",
+                null="If not applicable use: null",
+                todo="If a value is not yet available, use: todo",
             ),
         )

--- a/tox.ini
+++ b/tox.ini
@@ -20,9 +20,9 @@ passenv =
     *
 usedevelop = false
 deps =
-    pytest
+    pytest==7.1.2
     pytest-travis-fold
-    pytest-cov
+    pytest-cov==3.0.0
 commands =
      {posargs:pytest --cov --cov-report=term-missing -vv tests}
 


### PR DESCRIPTION
fix a error that is raised if minimum key metadata ({id:id}) is compiled - this field should not be changed by the user as it is part of the oemetadata spec definition and provides readable information on how to use the oemetadata

## What changed
Omi will not read the values of the oemetadta -> "_coment" key that is provided by the user - it will fall back to "hardcoded" values that are added to the _comment field