### PR TITLE
return error report if validate() is called and general code updates 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog
 current (2022-XX-XX)
 --------------------
 * update parser for v15 to handle former v13 key names, also update outdated License (data-)class in oem_v15 structure. (PR#77)
+* change the validation to return a report and enable report file creation option to the arguments of validation method. (PR#81)
 
 0.1.0 (2022-11-18)
 --------------------


### PR DESCRIPTION
- make save report activate/deactivateable by function interface,
- update available schema list as new oemetadata patch version was released
- update missing is_valid method in version specific parser classes
- return the report after validate() was called

fixes #80