### PR TITLE
Enhance omis oep table metadata tests

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,4 +1,5 @@
 """Tests for OMIs `base` package."""
+
 import pytest
 
 from omi import base, validation
@@ -6,7 +7,7 @@ from omi import base, validation
 
 def test_metadata_from_oep():
     """Test metadata from OEP."""
-    metadata = base.get_metadata_from_oep_table("ind_steel_pellet_1")
+    metadata = base.get_metadata_from_oep_table("omi_test_table_meta_v16", oep_schema="sandbox")
     validation.validate_metadata(metadata)
 
 


### PR DESCRIPTION
After omi was reworked, the testing system now attempts to validate data from table/metadata that is already on the OEP. The table that was used so far does not exist anymore, the test is failing.

This PR attempts fix this issue by using the sandbox schema for testing. Additionally, the table could be recreated if it does not exist anymore, as the sandbox schema is also cleaned up from time to time. 

During implementation i noticed that the OEP breaks schema validity of metadata that is uploaded as the OEP will fill all missing fields with "null" values. The json schema validation breaks after this change, as some fields are not expected to be None/null.

## What is new

New table for testing:

`sandox.omi_test_table_meta_v16` you can find the metadata that is available here:
https://openenergyplatform.org/api/v0/schema/sandbox/tables/omi_test_table_meta_v16/meta/

Table for oem v20 will follow 
